### PR TITLE
Capitalize User in generate scaffold

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -180,7 +180,7 @@ Setting this up is simple.
 First, let's create a `User` scaffold:
 
 ```bash
-$ bin/rails generate scaffold user name email login
+$ bin/rails generate scaffold User name email login
 $ bin/rails db:migrate
 ```
 


### PR DESCRIPTION
Capitalized User in "bin/rails generate scaffold User name email login" to follow best practice and conventions
